### PR TITLE
Bugfix due to API changes

### DIFF
--- a/docker-compose.yml.tmpl
+++ b/docker-compose.yml.tmpl
@@ -1,13 +1,13 @@
-web:
-    build: .
-    dockerfile: Dockerfile.server
-    command: ${opts}
+version: '3'
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+    command: "${opts}"
     ports:
         - 5000:5000
     volumes:
         - .:/app
-    links:
-        - db
-
-db:
+  db:
     image: redis

--- a/pwitter/config.py
+++ b/pwitter/config.py
@@ -1,8 +1,9 @@
 import ConfigParser as cp
+import os
 
 CONFIG_FILE = 'pwitter.conf'
 _CONF = cp.ConfigParser()
 _CONF.readfp(open(CONFIG_FILE))
 
 def get(opt, section='DEFAULT'):
-    return _CONF.get(section, opt)
+    return _CONF.get(section, opt, vars=os.environ)

--- a/pwitter/model.py
+++ b/pwitter/model.py
@@ -68,8 +68,7 @@ class Pweet(Entity):
     def on_save(self):
         _r.zadd(
             self._SET_KEY,
-            self.polarity, # the score
-            self.key
+            {self.key: self.polarity}
         )
 
     @classmethod
@@ -83,3 +82,11 @@ class Pweet(Entity):
             start=0, num=cls._LIMIT
         )
         return [cls.one(k) for k in keys]
+
+    def serialize(self):
+        return {
+            "body": self.body,
+            "polarity": self.polarity,
+            "subjectivity": self.subjectivity,
+            "user": self.user
+        }

--- a/pwitter/server.py
+++ b/pwitter/server.py
@@ -34,7 +34,7 @@ def post():
     pweet.validate()
     pweet.save()
 
-    return jsonify(pweet), 201
+    return jsonify(pweet.serialize()), 201
 
 @app.errorhandler(ValidationError)
 @app.errorhandler(ConversionError)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask
-redis
-schematics
-textblob
+flask==1.0.2
+redis==3.2.1
+schematics==2.1.0
+textblob==0.15.3


### PR DESCRIPTION
Hi there,

We are using this app as benchmark for a Kubernetes project in Polimi. During our work, we found that the code couldn't work with recent versions of some packages, Redis (`zadd`) and Flask (`jsonify`). I proposed a change in `pwitter/model.py` and `pwitter/server.py` to get them working.

We also have found useful to have the possibility to override the file configs with environment variables (changes in `pwitter/config.py`).

I think these fixes might be useful for other users and save time in getting the app working.